### PR TITLE
Fix package resolution to use module location instead of user cwd

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,21 +1,17 @@
 # Third-Party Notices
 
-This project depends on and wraps third-party packages. It does not fork their source.
-
 ## expo-mcp
 
 - Package: `expo-mcp`
-- Version: `0.2.4`
 - Upstream: `https://github.com/expo/expo-mcp`
-- License: MIT
+- License: MIT — Copyright (c) 2015-present 650 Industries, Inc. (aka Expo)
 - Usage in this project: lazily launched as a hidden child MCP after Metro is running and a dev server URL is known
 
 ## mobile-mcp
 
 - Package: `mobile-mcp`
-- Version: `0.0.7`
 - Upstream: `https://github.com/runablehq/mobile-mcp`
-- License: MIT
+- License: MIT — Copyright 2025 cloudycotton
 - Usage in this project: lazily launched as a hidden child MCP for screenshot and future device operations
 
 ## @modelcontextprotocol/sdk

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "expo-mcp": "^0.2.4",
         "fast-xml-parser": "^5.5.8",
-        "mobile-mcp": "0.0.7",
+        "mobile-mcp": "^0.0.7",
         "zod": "^4.3.6",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "expo-mcp": "^0.2.4",
     "fast-xml-parser": "^5.5.8",
-    "mobile-mcp": "0.0.7",
+    "mobile-mcp": "^0.0.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/integrations/expo-mcp-client.ts
+++ b/src/integrations/expo-mcp-client.ts
@@ -15,12 +15,10 @@ type TransportLike = {
 
 export function createExpoMcpIntegration(input?: {
   clock?: () => number;
-  cwd?: string;
   nodeCommand?: string;
   resolvePackageBin?: (input: {
     packageName: string;
     binName?: string;
-    cwd?: string;
   }) => Promise<string>;
   createClient?: () => McpClientLike;
   createTransport?: (input: {
@@ -31,7 +29,6 @@ export function createExpoMcpIntegration(input?: {
   }) => TransportLike;
 }): ExpoMcpIntegration {
   const clock = input?.clock ?? (() => Date.now());
-  const cwd = input?.cwd ?? process.cwd();
   const nodeCommand = input?.nodeCommand ?? process.execPath;
   const resolvePackageBin = input?.resolvePackageBin ?? defaultResolvePackageBin;
   const createClient =
@@ -54,8 +51,7 @@ export function createExpoMcpIntegration(input?: {
     async attach({ projectRoot, devServerUrl }) {
       const executablePath = await resolvePackageBin({
         packageName: "expo-mcp",
-        binName: "expo-mcp",
-        cwd
+        binName: "expo-mcp"
       });
 
       const transport = createTransport({

--- a/src/integrations/mobile-mcp-client.ts
+++ b/src/integrations/mobile-mcp-client.ts
@@ -47,7 +47,6 @@ export function createMobileMcpIntegration(input?: {
   resolvePackageBin?: (input: {
     packageName: string;
     binName?: string;
-    cwd?: string;
   }) => Promise<string>;
   createClient?: () => McpClientLike;
   createTransport?: (input: {
@@ -210,8 +209,7 @@ export function createMobileMcpIntegration(input?: {
     connectPromise ??= (async () => {
       const executablePath = await resolvePackageBin({
         packageName: "mobile-mcp",
-        binName: "mobile-mcp",
-        cwd
+        binName: "mobile-mcp"
       });
       const transport = createTransport({
         command: nodeCommand,

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -11,11 +11,8 @@ type PackageJson = {
 export async function resolvePackageBin(input: {
   packageName: string;
   binName?: string;
-  cwd?: string;
 }): Promise<string> {
-  const packageJsonPath = require.resolve(`${input.packageName}/package.json`, {
-    paths: [input.cwd ?? process.cwd()]
-  });
+  const packageJsonPath = require.resolve(`${input.packageName}/package.json`);
   const packageJson = JSON.parse(
     await readFile(packageJsonPath, "utf8")
   ) as PackageJson;

--- a/test/unit/paths.test.ts
+++ b/test/unit/paths.test.ts
@@ -35,19 +35,17 @@ describe("resolvePackageBin", () => {
   it("resolves the expo-mcp bin from installed package metadata", async () => {
     const resolved = await resolvePackageBin({
       packageName: "expo-mcp",
-      binName: "expo-mcp",
-      cwd: process.cwd()
+      binName: "expo-mcp"
     });
 
-    expect(resolved.replace(/\\/g, "/")).toMatch(/node_modules\/expo-mcp\/bin\/expo-mcp\.mjs$/);
+    expect(resolved.replace(/\\/g, "/")).toMatch(/expo-mcp\/bin\/expo-mcp\.mjs$/);
   });
 
   it("uses the sole declared bin when the bin name is omitted", async () => {
     const resolved = await resolvePackageBin({
-      packageName: "mobile-mcp",
-      cwd: process.cwd()
+      packageName: "mobile-mcp"
     });
 
-    expect(resolved.replace(/\\/g, "/")).toMatch(/node_modules\/mobile-mcp\/dist\/index\.js$/);
+    expect(resolved.replace(/\\/g, "/")).toMatch(/mobile-mcp\/dist\/index\.js$/);
   });
 });


### PR DESCRIPTION
resolvePackageBin used paths: [input.cwd ?? process.cwd()] which caused 'Cannot find module' errors when run via npx, because expo-mcp and mobile-mcp live next to local-expo-mcp in the npx cache, not in the user's project directory.

Removing the paths override lets createRequire(import.meta.url) resolve from the module's own location, which is always correct regardless of how the package is invoked.

Also removes the now-unused cwd parameter from resolvePackageBin and its callers in expo-mcp-client and mobile-mcp-client.